### PR TITLE
Allow for explicit file system in compiler options

### DIFF
--- a/apps/aesophia_http/src/aesophia_http_handler.erl
+++ b/apps/aesophia_http/src/aesophia_http_handler.erl
@@ -114,13 +114,19 @@ generate_aci(_Contract, _Options) ->
     %% TODO: Fill me in!
     {ok, <<>>}.
 
-compile_contract(Contract, _Options) ->
-    case aeso_compiler:from_string(binary_to_list(Contract), []) of
+compile_contract(Contract, Options) ->
+    Opts = compile_options(Options),
+    case aeso_compiler:from_string(binary_to_list(Contract), Opts) of
         {ok, Map} ->
             {ok, serialize(Map)};
         Err = {error, _} ->
             Err
     end.
+
+compile_options(Options) ->
+    Map = maps:get(<<"file_system">>, Options, #{}),
+    Map1 = maps:from_list([{binary_to_list(N), F} || {N, F} <- maps:to_list(Map)]),
+    [{include, {explicit_files, Map1}}].
 
 encode_calldata(Source, Function, Arguments) ->
     case aeso_compiler:create_calldata(binary_to_list(Source),

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -117,10 +117,16 @@ definitions:
       code:
         type: string
       options:
-        type: string
+        $ref: '#/definitions/CompileOpts'
     required:
       - code
       - options
+  CompileOpts:
+    type: object
+    properties:
+      file_system:
+        description: 'An explicit file system, mapping file names to file content'
+        type: object
   Error:
     type: object
     properties:

--- a/test/contracts/include.aes
+++ b/test/contracts/include.aes
@@ -1,0 +1,9 @@
+include "included.aes"
+include "../contracts/included2.aes"
+
+contract Include =
+  function foo() =
+    Included.foo() < Included2a.bar()
+
+  function bar() =
+    Included2b.foo() > Included.foo()

--- a/test/contracts/included.aes
+++ b/test/contracts/included.aes
@@ -1,0 +1,2 @@
+namespace Included =
+  function foo() = 42

--- a/test/contracts/included2.aes
+++ b/test/contracts/included2.aes
@@ -1,0 +1,5 @@
+namespace Included2a =
+  function bar() = 43
+
+namespace Included2b =
+  function foo() = 44


### PR DESCRIPTION
With this option the tools does not need to inline included files, it is enough to create a "virtual filesystem" and pass it as a parameter.