### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+*
+!rebar.config
+!rebar.lock
+!Makefile
+!apps
+!config
+!docker/entrypoint.sh
+!docker/healthcheck.sh
+!README.md
+!LICENSE
+apps/aesophia_http/priv/
+apps/aesophia_http/src/endpoints.erl


### PR DESCRIPTION
Add only required files to build the service as docker context to prevent sharing host machine build artefacts with docker.