### PR TITLE
Add CORS response headers (static allow-all)

### DIFF
--- a/apps/aesophia_http/src/aesophia_cors_middleware.erl
+++ b/apps/aesophia_http/src/aesophia_cors_middleware.erl
@@ -1,0 +1,75 @@
+%%%=============================================================================
+%%% @copyright (C) 2018, Aeternity Anstalt
+%%% @doc
+%%%    Cross-Origin Resource Sharing (CORS) middleware for Cowboy
+%%% @end
+%%%=============================================================================
+-module(aesophia_cors_middleware).
+
+-behaviour(cowboy_middleware).
+
+%% Behavior API
+-export([execute/2]).
+
+-define(ACCESS_CONTROL_ALLOWED_DOMAINS   , [<<"*">>]).
+-define(ACCESS_CONTROL_ALLOW_METHODS     , <<"DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT">>).
+-define(ACCESS_CONTROL_MAX_AGE           , 30 * 60). %% 30 minutes
+-define(ACCESS_CONTROL_ALLOW_CREDENTIALS , <<"true">>).
+
+%%%===================================================================
+%%% Behaviour API
+%%%===================================================================
+
+-spec execute(cowboy_req:req(), cowboy_middleware:env()) -> {ok, cowboy_req:req(), cowboy_middleware:env()}.
+execute(Req, Env) ->
+    Req2 = set_cors_headers(Req),
+    case cowboy_req:method(Req2) of
+        <<"OPTIONS">> -> {stop, cowboy_req:reply(200, Req2)};
+        _             -> {ok, Req2, Env}
+    end.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+-spec set_cors_headers(cowboy_req:req()) -> cowboy_req:req().
+set_cors_headers(Req1) ->
+    case cowboy_req:header(<<"origin">>, Req1) of
+        undefined ->
+            Req1;
+        Origin ->
+            case is_allowed(Origin, ?ACCESS_CONTROL_ALLOWED_DOMAINS) of
+                true ->
+                    set_cors_headers(Req1, Origin);
+                false ->
+                    Req1
+            end
+    end.
+
+is_allowed(Origin, AllowedDomains) ->
+    case lists:member(<<"*">>, AllowedDomains) of
+        true  -> true;
+        false -> lists:member(Origin, AllowedDomains)
+    end.
+
+set_cors_headers(Req, Origin) ->
+    SetHeader =
+        fun({Header, Value}, R) ->
+                cowboy_req:set_resp_header(Header, Value, R)
+        end,
+    Headers = cors_headers(Req, Origin),
+    lists:foldl(SetHeader, Req, Headers).
+
+cors_headers(Req, Origin) ->
+    MaxAge       = ?ACCESS_CONTROL_MAX_AGE,
+    CorsHeaders =
+        [{<<"access-control-allow-origin">>      , Origin},
+         {<<"access-control-allow-methods">>     , ?ACCESS_CONTROL_ALLOW_METHODS},
+         {<<"access-control-allow-credentials">> , ?ACCESS_CONTROL_ALLOW_CREDENTIALS},
+         {<<"access-control-max-age">>           , integer_to_list(MaxAge)}],
+    case cowboy_req:header(<<"access-control-request-headers">>, Req) of
+        undefined ->
+            CorsHeaders;
+        AllowHeaders ->
+            [{<<"access-control-allow-headers">>, AllowHeaders} | CorsHeaders]
+    end.

--- a/apps/aesophia_http/src/aesophia_http_app.erl
+++ b/apps/aesophia_http/src/aesophia_http_app.erl
@@ -22,7 +22,10 @@ start(_StartType, _StartArgs) ->
 				      {'_',Paths}
 				     ]),
     {ok,_} =  cowboy:start_clear(http, [{port,Port}],
-				 #{env => #{dispatch => Dispatch}}),
+				 #{env => #{dispatch => Dispatch},
+                   middlewares => [cowboy_router,
+                                   aesophia_cors_middleware,
+                                   cowboy_handler]}),
     aesophia_http_sup:start_link().
 
 %%--------------------------------------------------------------------
@@ -41,4 +44,3 @@ get_paths() ->
 path(Path0) ->
     Path1 = binary:replace(Path0, <<"}">>, <<"">>, [global]),
     binary:replace(Path1, <<"{">>, <<":">>, [global]).
-


### PR DESCRIPTION
Port/Copy of https://github.com/aeternity/aeternity/blob/master/apps/aehttp/src/aehttp_cors_middleware.erl

I propose static implementation as I believe 99% of the use-cases needs "allow all". However, I kept the original structure so that configuration can be added in future if needed.

Perhaps I could try adding a tests, but the test structure does not handle headers yet, so it's a bit more work for me to do it.

Thanks so @zp-sd to help me find out that a middleware should be in the *middle* of standard cowbow middlewares 🤣 