### PR TITLE
Add missing field of DecodeCalldataSource in swagger.yaml

### DIFF
--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -399,9 +399,16 @@ definitions:
       calldata:
         description: 'Calldata to dissect'
         $ref: '#/definitions/EncodedByteArray'
+      function:
+        description: 'Name of the function to call'
+        type: string
       source:
         description: '(Possibly partial) Sophia contract code'
         type: string
+    required:
+      - calldata
+      - function
+      - source
   DecodedCalldata:
     type: object
     properties:


### PR DESCRIPTION
Decode calldata from source needs a function parameter as well and all fields are required [according to it's handler](https://github.com/aeternity/aesophia_http/blob/master/apps/aesophia_http/src/aesophia_http_handler.erl#L116-L119)