### PR TITLE
Always return Vary header with CORS headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+- Always return `Vary` HTTP header together with CORS headers to prevent caching issues
 ### Removed
 
 ## [4.2.0] - 2020-01-15

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ $(HTTP_APP)/priv/swagger.json: config/swagger.yaml
 	@rm -fr $(SWTEMP)
 
 $(SWAGGER_CODEGEN_CLI):
-	curl -fsS --create-dirs -o $@ http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/$(SWAGGER_CODEGEN_CLI_V)/swagger-codegen-cli-$(SWAGGER_CODEGEN_CLI_V).jar
+	curl -fsS --create-dirs -o $@ https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/$(SWAGGER_CODEGEN_CLI_V)/swagger-codegen-cli-$(SWAGGER_CODEGEN_CLI_V).jar
 
 $(SWAGGER_ENDPOINTS_SPEC): config/swagger.yaml
 	$(REBAR) swagger_endpoints

--- a/apps/aesophia_http/src/aesophia_cors_middleware.erl
+++ b/apps/aesophia_http/src/aesophia_cors_middleware.erl
@@ -63,7 +63,8 @@ set_cors_headers(Req, Origin) ->
 cors_headers(Req, Origin) ->
     MaxAge       = ?ACCESS_CONTROL_MAX_AGE,
     CorsHeaders =
-        [{<<"access-control-allow-origin">>      , Origin},
+        [{<<"vary">>                             , <<"origin">>},
+         {<<"access-control-allow-origin">>      , Origin},
          {<<"access-control-allow-methods">>     , ?ACCESS_CONTROL_ALLOW_METHODS},
          {<<"access-control-allow-credentials">> , ?ACCESS_CONTROL_ALLOW_CREDENTIALS},
          {<<"access-control-max-age">>           , integer_to_list(MaxAge)}],


### PR DESCRIPTION
This invalidates the caches based on Origin header,
otherwise invalid cache record (last response) is returned for any Origin header,
which fails the CORS checks if the domain/URL is changed.