### PR TITLE
fix: define items field to fix generation error using go-swagger

### DIFF
--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -454,6 +454,8 @@ definitions:
         type: object
       external_encoded_aci:
         type: array
+        items:
+          type: object
       interface:
         type: string
     required:


### PR DESCRIPTION
$ swagger generate client -f api/compiler.json -A compiler --with-flatten=minimal --target swagguard/compiler
2021/06/09 15:22:08 validating spec /.../aepp-sdk-go/api/compiler.json
The swagger spec at "/.../aepp-sdk-go/api/compiler.json" is invalid against swagger specification 2.0. see errors :
- items in definitions.ACI.properties.external_encoded_aci is required