### PR TITLE
Drop schemes from swagger file

### DIFF
--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -7,8 +7,6 @@ info:
   contact:
     email: apiteam@aeternity.com
 basePath: /
-schemes:
-  - http
 paths:
   /aci:
     post:


### PR DESCRIPTION
> If schemes are not specified, the scheme used to serve the API specification will be used for API calls.

ref: https://swagger.io/docs/specification/2-0/api-host-and-base-path/

Related issues:
- https://github.com/aeternity/aepp-sdk-js/issues/1225
- https://github.com/aeternity/aepp-sdk-js/issues/1225#issuecomment-863985169
- https://github.com/aeternity/aesophia_http/issues/70
- https://github.com/aeternity/aesophia_http/issues/70#issuecomment-865188084
- https://github.com/aeternity/ae_mdw/issues/160