### PR TITLE
Don't require options object

### DIFF
--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -377,7 +377,6 @@ definitions:
         $ref: '#/definitions/CompileOpts'
     required:
       - code
-      - options
   CompileOpts:
     type: object
     properties:
@@ -609,7 +608,6 @@ definitions:
     required:
       - bytecode
       - source
-      - options
   DecodedCallresult:
     type: object
     properties:


### PR DESCRIPTION
I'm creating an api wrapper using Autorest and would like to get rid of necessity to pass `options: {}`.

blocked by #88 