### PR TITLE
Rename APIVersion to ApiVersion

### DIFF
--- a/apps/aesophia_http/src/aesophia_http_handler.erl
+++ b/apps/aesophia_http/src/aesophia_http_handler.erl
@@ -257,7 +257,7 @@ handle_request('Version', _Req, _Context) ->
             {500, [], #{reason => <<"Internal error: Could not find the version!?">>}}
     end;
 
-handle_request('APIVersion', _Req, #{ spec := Spec }) ->
+handle_request('ApiVersion', _Req, #{ spec := Spec }) ->
     case jsx:decode(Spec, [return_maps]) of
         #{ <<"info">> := #{ <<"version">> := Vsn } } ->
             {200, [], #{'api-version' => Vsn}};

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -336,7 +336,7 @@ paths:
 
   /api-version:
     get:
-      operationId: 'APIVersion'
+      operationId: 'ApiVersion'
       description: 'Get the version of the API'
       produces:
         - application/json
@@ -344,7 +344,7 @@ paths:
         '200':
           description: 'Sophia compiler version'
           schema:
-            $ref: '#/definitions/APIVersion'
+            $ref: '#/definitions/ApiVersion'
         '500':
           description: 'Error'
           schema:
@@ -391,7 +391,7 @@ definitions:
       src_file:
         description: 'Name of contract source file - only used in error messages'
         type: string
-  APIVersion:
+  ApiVersion:
     type: object
     properties:
       api-version:


### PR DESCRIPTION
In JS SDK we are using autorest to generate TS api, by default it generates method named by `operationId` with a changed casing, it works fine except for this method: `aPIVersion`
https://github.com/aeternity/aepp-sdk-js/blob/a7fe9563cadeca469404bb8de13afd81242b81a2/src/contract/compiler.js#L99