### PR TITLE
Use get requests instead of post, add headers to enable caching (not working)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ contract="contract SimpleStorage =
 To get the ACI of the contract we use the `/aci` interface:
 
 ```
-curl -H "Content-Type: application/json" -d "{\"code\":\"$contract\",\"options\":{}}" -X POST http://localhost:3080/aci
+curl -H "Content-Type: application/json" -d "{\"code\":\"$contract\",\"options\":{}}" -X GET http://localhost:3080/aci
 ```
 Returns:
 ```
@@ -104,7 +104,7 @@ other contracts.
 We can now compile the contract and get the bytecode:
 
 ```
-url -H "Content-Type: application/json" -d "{\"code\":\"$contract\", \"options\":{}}" -X POST http://localhost:3080/compile
+url -H "Content-Type: application/json" -d "{\"code\":\"$contract\", \"options\":{}}" -X GET http://localhost:3080/compile
 ```
 Returns:
 ```
@@ -117,7 +117,7 @@ You can check that some particular bytecode, for instance obtained from the
 chain, was compiled from given source code, using the `validate-byte-code`
 endpoint:
 ```
-curl -H "Content-Type: application/json" -d '{"source":"contract Id = entrypoint id(x : int) = x","options":{},"bytecode":"cb_+GNGA6CBDP58NrY5L7PzZrlGZ0C8aqcXIYwqv2WMpyTg8IuBTsC3nv5E1kQfADcANwAaDoI/AQM//tjzDDgANwEHBwEBAJQvAhFE1kQfEWluaXQR2PMMOAlpZIIvAIU0LjAuMABqFanJ"}' -X POST http://localhost:3080/validate-byte-code
+curl -H "Content-Type: application/json" -d '{"source":"contract Id = entrypoint id(x : int) = x","options":{},"bytecode":"cb_+GNGA6CBDP58NrY5L7PzZrlGZ0C8aqcXIYwqv2WMpyTg8IuBTsC3nv5E1kQfADcANwAaDoI/AQM//tjzDDgANwEHBwEBAJQvAhFE1kQfEWluaXQR2PMMOAlpZIIvAIU0LjAuMABqFanJ"}' -X GET http://localhost:3080/validate-byte-code
 ```
 Returns:
 ```
@@ -132,7 +132,7 @@ Validating against source code with a different implementation of `id` returns:
 
 You can get the FATE assembler code for some particular bytecode:
 ```
-curl -H "Content-Type: application/json" -d '{"bytecode":"cb_+GNGA6CBDP58NrY5L7PzZrlGZ0C8aqcXIYwqv2WMpyTg8IuBTsC3nv5E1kQfADcANwAaDoI/AQM//tjzDDgANwEHBwEBAJQvAhFE1kQfEWluaXQR2PMMOAlpZIIvAIU0LjAuMABqFanJ"}' -X POST http://localhost:3080/fate-assembler
+curl -H "Content-Type: application/json" -d '{"bytecode":"cb_+GNGA6CBDP58NrY5L7PzZrlGZ0C8aqcXIYwqv2WMpyTg8IuBTsC3nv5E1kQfADcANwAaDoI/AQM//tjzDDgANwEHBwEBAJQvAhFE1kQfEWluaXQR2PMMOAlpZIIvAIU0LjAuMABqFanJ"}' -X GET http://localhost:3080/fate-assembler
 ```
 Returns:
 ```
@@ -145,7 +145,7 @@ To encode the call data necessary to call the function `set` with the
 argument `42`:
 
 ```
-curl -H "Content-Type: application/json" -d "{\"function\":\"set\",\"arguments\":[\"42\"],\"source\":\"$contract\", \"options\":{}}" -X POST http://localhost:3080/encode-calldata
+curl -H "Content-Type: application/json" -d "{\"function\":\"set\",\"arguments\":[\"42\"],\"source\":\"$contract\", \"options\":{}}" -X GET http://localhost:3080/encode-calldata
 ```
 Returns:
 ```
@@ -160,7 +160,7 @@ Call data from transactions can be decoded in two ways, either using the contrac
 
 Example:
 ```
-curl -H "Content-Type: application/json" -d "{\"calldata\":\"cb_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACA6hZQte0c6B/XQTuHZwWpc6rFreRzqkolhGkTD+eW6BwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACoA4Uun\",\"bytecode\":\"cb_+QYYRgKgCTTJlUBVAUHWm6tXQKIwDZi3yvR+jeNv8JCPQzLT6xT5BKX5AUmgOoWULXtHOgf10E7h2cFqXOqxa3kc6pKJYRpEw/nlugeDc2V0uMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoP//////////////////////////////////////////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC4YAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP///////////////////////////////////////////jJoEnsSQdsAgNxJqQzA+rc5DsuLDKUV7ETxQp+ItyJgJS3g2dldLhgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA///////////////////////////////////////////uEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA+QKLoOIjHWzfyTkW3kyzqYV79lz0D8JW9KFJiz9+fJgMGZNEhGluaXS4wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACg//////////////////////////////////////////8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALkBoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEA//////////////////////////////////////////8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYD//////////////////////////////////////////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuQFEYgAAj2IAAMKRgICAUX9J7EkHbAIDcSakMwPq3OQ7LiwylFexE8UKfiLciYCUtxRiAAE5V1CAgFF/4iMdbN/JORbeTLOphXv2XPQPwlb0oUmLP358mAwZk0QUYgAA0VdQgFF/OoWULXtHOgf10E7h2cFqXOqxa3kc6pKJYRpEw/nlugcUYgABG1dQYAEZUQBbYAAZWWAgAZCBUmAgkANgAFmQgVKBUllgIAGQgVJgIJADYAOBUpBZYABRWVJgAFJgAPNbYACAUmAA81tgAFFRkFZbYCABUVGQUIOSUICRUFCAWZCBUllgIAGQgVJgIJADYAAZWWAgAZCBUmAgkANgAFmQgVKBUllgIAGQgVJgIJADYAOBUoFSkFCQVltgIAFRUVlQgJFQUGAAUYFZkIFSkFBgAFJZkFCQVltQUFlQUGIAAMpWhTIuMC4w4czHnw==\"}" -X POST http://localhost:3080/decode-calldata/bytecode
+curl -H "Content-Type: application/json" -d "{\"calldata\":\"cb_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACA6hZQte0c6B/XQTuHZwWpc6rFreRzqkolhGkTD+eW6BwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACoA4Uun\",\"bytecode\":\"cb_+QYYRgKgCTTJlUBVAUHWm6tXQKIwDZi3yvR+jeNv8JCPQzLT6xT5BKX5AUmgOoWULXtHOgf10E7h2cFqXOqxa3kc6pKJYRpEw/nlugeDc2V0uMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoP//////////////////////////////////////////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC4YAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP///////////////////////////////////////////jJoEnsSQdsAgNxJqQzA+rc5DsuLDKUV7ETxQp+ItyJgJS3g2dldLhgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA///////////////////////////////////////////uEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA+QKLoOIjHWzfyTkW3kyzqYV79lz0D8JW9KFJiz9+fJgMGZNEhGluaXS4wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACg//////////////////////////////////////////8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALkBoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEA//////////////////////////////////////////8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYD//////////////////////////////////////////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuQFEYgAAj2IAAMKRgICAUX9J7EkHbAIDcSakMwPq3OQ7LiwylFexE8UKfiLciYCUtxRiAAE5V1CAgFF/4iMdbN/JORbeTLOphXv2XPQPwlb0oUmLP358mAwZk0QUYgAA0VdQgFF/OoWULXtHOgf10E7h2cFqXOqxa3kc6pKJYRpEw/nlugcUYgABG1dQYAEZUQBbYAAZWWAgAZCBUmAgkANgAFmQgVKBUllgIAGQgVJgIJADYAOBUpBZYABRWVJgAFJgAPNbYACAUmAA81tgAFFRkFZbYCABUVGQUIOSUICRUFCAWZCBUllgIAGQgVJgIJADYAAZWWAgAZCBUmAgkANgAFmQgVKBUllgIAGQgVJgIJADYAOBUoFSkFCQVltgIAFRUVlQgJFQUGAAUYFZkIFSkFBgAFJZkFCQVltQUFlQUGIAAMpWhTIuMC4w4czHnw==\"}" -X GET http://localhost:3080/decode-calldata/bytecode
 ```
 
 Returns:
@@ -171,7 +171,7 @@ Returns:
 And secondly, using the Sophia contract source which returns the Sophia types and values:
 
 ```
-curl -H "Content-Type: application/json" -d "{\"calldata\":\"cb_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACA6hZQte0c6B/XQTuHZwWpc6rFreRzqkolhGkTD+eW6BwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACoA4Uun\",\"function\":\"set\",\"source\":\"$contract\"}" -X POST http://localhost:3080/decode-calldata/source
+curl -H "Content-Type: application/json" -d "{\"calldata\":\"cb_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACA6hZQte0c6B/XQTuHZwWpc6rFreRzqkolhGkTD+eW6BwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACoA4Uun\",\"function\":\"set\",\"source\":\"$contract\"}" -X GET http://localhost:3080/decode-calldata/source
 ```
 
 Returns:
@@ -183,7 +183,7 @@ Returns:
 You can also decode the return value of a contract call:
 
 ```
-curl -H "Content-Type: application/json" -d "{\"source\":\"$contract\",\"function\":\"get\", \"call-result\":\"ok\", \"call-value\":\"cb_VNLOFXc=\"}" -X POST http://localhost:3080/decode-call-result
+curl -H "Content-Type: application/json" -d "{\"source\":\"$contract\",\"function\":\"get\", \"call-result\":\"ok\", \"call-value\":\"cb_VNLOFXc=\"}" -X GET http://localhost:3080/decode-call-result
 ```
 
 Returns:
@@ -194,7 +194,7 @@ Returns:
 The contract call result can also be decoded using the `bytecode` as a starting point:
 
 ```
-curl -H "Content-Type: application/json" -d "{\"bytecode\":\"cb_+JFGA6DcSHcAbyhLqfbIDJRe1S7ZJLCZQJBUuvMmCLK5OirpHsC4YLg8/i+GW9kANwAHKCwAggD+RNZEHwA3AQc3AAwBACcMAhoCggEDP/7oxF62ADcBBzcADAEAJwwCGgKCAQM/ni8DES+GW9kNZ2V0EUTWRB8RaW5pdBHoxF62DXNldIIvAIk0LjAuMC1yYzQAPwYsew==\",\"function\":\"get\", \"call-result\":\"ok\", \"call-value\":\"cb_VNLOFXc=\"}" -X POST http://localhost:3080/decode-call-result/bytecode
+curl -H "Content-Type: application/json" -d "{\"bytecode\":\"cb_+JFGA6DcSHcAbyhLqfbIDJRe1S7ZJLCZQJBUuvMmCLK5OirpHsC4YLg8/i+GW9kANwAHKCwAggD+RNZEHwA3AQc3AAwBACcMAhoCggEDP/7oxF62ADcBBzcADAEAJwwCGgKCAQM/ni8DES+GW9kNZ2V0EUTWRB8RaW5pdBHoxF62DXNldIIvAIk0LjAuMC1yYzQAPwYsew==\",\"function\":\"get\", \"call-result\":\"ok\", \"call-value\":\"cb_VNLOFXc=\"}" -X GET http://localhost:3080/decode-call-result/bytecode
 ```
 
 Returns:
@@ -206,7 +206,7 @@ Returns:
 You can extract the compiler version that was used to compile some particular bytecode:
 
 ```
-curl -H "Content-Type: application/json" -d '{"bytecode":"cb_+GNGA6CBDP58NrY5L7PzZrlGZ0C8aqcXIYwqv2WMpyTg8IuBTsC3nv5E1kQfADcANwAaDoI/AQM//tjzDDgANwEHBwEBAJQvAhFE1kQfEWluaXQR2PMMOAlpZIIvAIU0LjAuMABqFanJ"}' -X POST http://localhost:3080/compiler-version
+curl -H "Content-Type: application/json" -d '{"bytecode":"cb_+GNGA6CBDP58NrY5L7PzZrlGZ0C8aqcXIYwqv2WMpyTg8IuBTsC3nv5E1kQfADcANwAaDoI/AQM//tjzDDgANwEHBwEBAJQvAhFE1kQfEWluaXQR2PMMOAlpZIIvAIU0LjAuMABqFanJ"}' -X GET http://localhost:3080/compiler-version
 ```
 
 Returns:

--- a/apps/aesophia_http/src/aesophia_cache_middleware.erl
+++ b/apps/aesophia_http/src/aesophia_cache_middleware.erl
@@ -1,0 +1,23 @@
+%%%=============================================================================
+%%% @copyright (C) 2022, Aeternity Anstalt
+%%% @doc
+%%%    Caching middleware for Cowboy
+%%% @end
+%%%=============================================================================
+-module(aesophia_cache_middleware).
+
+-behaviour(cowboy_middleware).
+
+%% Behavior API
+-export([execute/2]).
+
+-define(CACHE_CONTROL , <<"public, max-age=604800, immutable">>).
+
+%%%===================================================================
+%%% Behaviour API
+%%%===================================================================
+
+-spec execute(cowboy_req:req(), cowboy_middleware:env()) -> {ok, cowboy_req:req(), cowboy_middleware:env()}.
+execute(Req, Env) ->
+    Req2 = cowboy_req:set_resp_header(<<"cache-control">>, ?CACHE_CONTROL, Req),
+    {ok, Req2, Env}.

--- a/apps/aesophia_http/src/aesophia_http_app.erl
+++ b/apps/aesophia_http/src/aesophia_http_app.erl
@@ -25,6 +25,7 @@ start(_StartType, _StartArgs) ->
 				 #{env => #{dispatch => Dispatch},
                    middlewares => [cowboy_router,
                                    aesophia_cors_middleware,
+                                   aesophia_cache_middleware,
                                    cowboy_handler]}),
     aesophia_http_sup:start_link().
 

--- a/apps/aesophia_http/src/aesophia_http_handler.erl
+++ b/apps/aesophia_http/src/aesophia_http_handler.erl
@@ -20,7 +20,7 @@ init(Req, OperationId) ->
     {cowboy_rest, Req, State}.
 
 allowed_methods(Req, State) ->
-    Methods = [<<"GET">>,<<"POST">>],
+    Methods = [<<"GET">>],
     {Methods,Req,State}.
 
 content_types_accepted(Req, State) ->

--- a/apps/aesophia_http/test/aesophia_http_SUITE.erl
+++ b/apps/aesophia_http/test/aesophia_http_SUITE.erl
@@ -475,58 +475,58 @@ do_get_fate_assembler(CB) ->
 
 get_contract_bytecode(SourceCode, Opts) ->
     Host = internal_address(),
-    http_request(Host, post, "compile",
+    http_request(Host, in_body, "compile",
                  #{ <<"code">> => SourceCode, <<"options">> => Opts }).
 
 get_aci(SourceCode, Opts) ->
     Host = internal_address(),
-    http_request(Host, post, "aci",
+    http_request(Host, in_body, "aci",
                  #{ <<"code">> => SourceCode, <<"options">> => Opts }).
 
 
 get_encode_calldata(Request) ->
     Host = internal_address(),
-    http_request(Host, post, "encode-calldata", Request).
+    http_request(Host, in_body, "encode-calldata", Request).
 
 get_decode_calldata_bytecode(Request) ->
     Host = internal_address(),
-    http_request(Host, post, "decode-calldata/bytecode", Request).
+    http_request(Host, in_body, "decode-calldata/bytecode", Request).
 
 get_decode_calldata_source(Request) ->
     Host = internal_address(),
-    http_request(Host, post, "decode-calldata/source", Request).
+    http_request(Host, in_body, "decode-calldata/source", Request).
 
 get_decode_call_result(Request) ->
     Host = internal_address(),
-    http_request(Host, post, "decode-call-result", Request).
+    http_request(Host, in_body, "decode-call-result", Request).
 
 get_decode_call_result_bytecode(Request) ->
     Host = internal_address(),
-    http_request(Host, post, "decode-call-result/bytecode", Request).
+    http_request(Host, in_body, "decode-call-result/bytecode", Request).
 
 get_validate_byte_code(Request) ->
     Host = internal_address(),
-    http_request(Host, post, "validate-byte-code", Request).
+    http_request(Host, in_body, "validate-byte-code", Request).
 
 get_fate_assembler(Request) ->
     Host = internal_address(),
-    http_request(Host, post, "fate-assembler", Request).
+    http_request(Host, in_body, "fate-assembler", Request).
 
 get_compiler_version(Request) ->
     Host = internal_address(),
-    http_request(Host, post, "compiler-version", Request).
+    http_request(Host, in_body, "compiler-version", Request).
 
 get_api_version() ->
     Host = internal_address(),
-    http_request(Host, get, "api-version", []).
+    http_request(Host, in_query, "api-version", []).
 
 get_version() ->
     Host = internal_address(),
-    http_request(Host, get, "version", []).
+    http_request(Host, in_query, "version", []).
 
 get_api() ->
     Host = internal_address(),
-    http_request(Host, get, "api", []).
+    http_request(Host, in_query, "api", []).
 
 %% ============================================================
 %% private functions
@@ -536,13 +536,13 @@ internal_address() ->
     {ok, Port} = application:get_env(aesophia_http, port),
     "http://127.0.0.1:" ++ integer_to_list(Port).
 
-http_request(Host, get, Path, Params) ->
+http_request(Host, in_query, Path, Params) ->
     URL = binary_to_list(
             iolist_to_binary([Host, "/", Path, encode_get_params(Params)])),
     ct:log("GET ~p", [URL]),
     R = httpc_request(get, {URL, []}, [], []),
     process_http_return(R);
-http_request(Host, post, Path, Params) ->
+http_request(Host, in_body, Path, Params) ->
     URL = binary_to_list(iolist_to_binary([Host, "/", Path])),
     {Type, Body} = case Params of
                        Map when is_map(Map) ->
@@ -552,8 +552,7 @@ http_request(Host, post, Path, Params) ->
                            {"application/x-www-form-urlencoded",
                             http_uri:quote(Path)}
                    end,
-    %% lager:debug("Type = ~p; Body = ~p", [Type, Body]),
-    ct:log("POST ~p, type ~p, Body ~p", [URL, Type, Body]),
+    ct:log("GET ~p, type ~p, Body ~p", [URL, Type, Body]),
     R = httpc_request(post, {URL, [], Type, Body}, [], []),
     process_http_return(R).
 

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -9,7 +9,7 @@ info:
 basePath: /
 paths:
   /aci:
-    post:
+    get:
       operationId: 'GenerateACI'
       description: 'Generate an Aeternity Contract Interface (ACI) for contract'
       consumes:
@@ -38,7 +38,7 @@ paths:
             $ref: '#/definitions/CompilerErrors'
 
   /compile:
-    post:
+    get:
       operationId: 'CompileContract'
       description: 'Compile a sophia contract from source and return byte code'
       consumes:
@@ -67,7 +67,7 @@ paths:
             $ref: '#/definitions/CompilerErrors'
 
   /decode-call-result:
-    post:
+    get:
       operationId: 'DecodeCallResult'
       description: 'Decode the result of contract call'
       consumes:
@@ -96,7 +96,7 @@ paths:
             $ref: '#/definitions/CompilerErrors'
 
   /decode-call-result/bytecode:
-    post:
+    get:
       operationId: 'DecodeCallResultBytecode'
       description: 'Decode the result of contract call from Bytecode'
       consumes:
@@ -125,7 +125,7 @@ paths:
             $ref: '#/definitions/CompilerErrors'
 
   /encode-calldata:
-    post:
+    get:
       operationId: 'EncodeCalldata'
       description: 'Encode Sophia function call according to sophia ABI.'
       consumes:
@@ -154,7 +154,7 @@ paths:
             $ref: '#/definitions/CompilerErrors'
 
   /decode-calldata/bytecode:
-    post:
+    get:
       operationId: 'DecodeCalldataBytecode'
       description: 'Identify function name and arguments in Calldata for a compiled contract'
       consumes:
@@ -183,7 +183,7 @@ paths:
             $ref: '#/definitions/Error'
 
   /decode-calldata/source:
-    post:
+    get:
       operationId: 'DecodeCalldataSource'
       description: 'Identify function name and arguments in Calldata for a (partial) contract'
       consumes:
@@ -212,7 +212,7 @@ paths:
             $ref: '#/definitions/CompilerErrors'
 
   /fate-assembler:
-    post:
+    get:
       operationId: 'GetFateAssemblerCode'
       description: 'Get FATE assembler code from bytecode'
       consumes:
@@ -238,7 +238,7 @@ paths:
 
 
   /validate-byte-code:
-    post:
+    get:
       operationId: 'ValidateByteCode'
       description: 'Verify that an encoded byte array is the result of compiling a given contract'
       consumes:
@@ -265,7 +265,7 @@ paths:
             $ref: '#/definitions/CompilerErrors'
 
   /compiler-version:
-    post:
+    get:
       operationId: 'GetCompilerVersion'
       description: 'Extract compiler version from bytecode'
       consumes:


### PR DESCRIPTION
I'm trying to enable caching of compiler responses as I'm proposed in https://github.com/aeternity/aepp-sdk-js/issues/1681#issuecomment-1289111343

Firstly I've added the "Cache-Control" header as middleware, but I found that POST requests can't be cached https://stackoverflow.com/a/626083/6176994. Later I new that GET requests don't support the request body in some environments (for example `fetch` in browser fails with "Request with GET/HEAD method cannot have body").

The rest option is to encode parameters in query part of URL instead of request body, but URL length is limited in some environments https://stackoverflow.com/a/417184/6176994 It could work well in modern browsers the same way as data URLs, but it needs additional testing.

To use POST in compiler methods is not semantic because compiler doesn't have its own state, but there is no easy way to replace it.


A page for testing:
```html
<!DOCTYPE html>
<html lang="en">
<body>
<a href="./test.html">test.html</a>
<div id="output"></div>
<script>
  async function getRequestTime() {
    const timeBefore = Date.now();
    const request = await fetch('http://localhost:3080/compile', {
      method: 'POST',
      headers: {
        'Content-Type': 'application/json',
      },
      body: JSON.stringify({
        code: 'main contract Identity =\n  entrypoint main_fun (x:int) = x',
      }),
    });
    await request.json();
    return Date.now() - timeBefore;
  }

  (async () => {
    const output = document.getElementById('output');
    for (let i = 0; i < 10; i++) {
      output.innerText += `compile request ${i}: ${await getRequestTime()}\n`;
    }
  })();
</script>
</body>
</html>
```