### PR TITLE
Prepare v7.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## [7.5.0]
+### Changed
+- Updated to [Sophia 7.3.0](https://github.com/aeternity/aesophia/blob/master/CHANGELOG.md#730)
+- Aligned HTTP API version with HTTP Compiler version (7.5.0) - Sophia compiler version is 7.3.0
+
 ## [7.4.0]
 ### Added
 - GenerateACI accepts contract interface again
@@ -162,7 +167,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial HTTP interface: /aci, /compile, /decode-data, /encode-calldata, /version, /api-version, /api
 - Docker support (aeternity/aesophia_http)
 
-[Unreleased]: https://github.com/aeternity/aesophia_http/compare/v7.4.0...HEAD
+[Unreleased]: https://github.com/aeternity/aesophia_http/compare/v7.5.0...HEAD
+[7.5.0]: https://github.com/aeternity/aesophia_http/compare/v7.4.0...v7.5.0
 [7.4.0]: https://github.com/aeternity/aesophia_http/compare/v7.3.0...v7.4.0
 [7.3.0]: https://github.com/aeternity/aesophia_http/compare/v7.2.0...v7.3.0
 [7.2.0]: https://github.com/aeternity/aesophia_http/compare/v7.1.1...v7.2.0

--- a/README.md
+++ b/README.md
@@ -221,13 +221,13 @@ version and the whole actual API (paste into any [swagger file generator](https:
 ```
 curl http://localhost:3080/version
 
-{"version":"7.2.1"}
+{"version":"7.3.0"}
 ```
 
 ```
 curl http://localhost:3080/api-version
 
-{"api-version":"7.3.0"}
+{"api-version":"7.5.0"}
 ```
 
 ```

--- a/apps/aesophia_http/src/aesophia_http.app.src
+++ b/apps/aesophia_http/src/aesophia_http.app.src
@@ -1,6 +1,6 @@
 {application, aesophia_http,
  [{description, "HTTP interface for Sophia compiler"},
-  {vsn, "7.4.0"},
+  {vsn, "7.5.0"},
   {registered, []},
   {mod, { aesophia_http_app, []}},
   {applications,

--- a/apps/aesophia_http/test/aesophia_http_SUITE.erl
+++ b/apps/aesophia_http/test/aesophia_http_SUITE.erl
@@ -362,8 +362,8 @@ fate_assembler(_) ->
     C = <<"cb_+GZGA6CpNW171TSUfk88PoVv7YslUgxRcOJYKFPRxoGkXArWosC4OZ7+RNZEHwA3ADcAGg6CPwEDP/64F37sADcBBwcBAQCWLwIRRNZEHxFpbml0EbgXfuwRbWFpboIvAIU0LjEuMAANEx2r">>,
     _Res = do_get_fate_assembler(C).
 
--define(API_VERSION,      <<"7.3.0">>).
--define(COMPILER_VERSION, <<"7.2.1">>).
+-define(API_VERSION,      <<"7.5.0">>).
+-define(COMPILER_VERSION, <<"7.3.0">>).
 
 compiler_version(_) ->
     F = fun({ExpVer, CB}) ->

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   description: 'This is the [Aeternity](https://www.aeternity.com/) compiler API.'
-  version: 7.3.0
+  version: 7.5.0
   title: Aeternity compiler
   termsOfService: 'https://www.aeternity.com/terms/'
   contact:

--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,7 @@
         {aebytecode, {git, "https://github.com/aeternity/aebytecode.git",
                            {tag, "v3.1.1"}}},
         {aesophia, {git, "https://github.com/aeternity/aesophia.git",
-                    {tag, "v7.2.1"}}},
+                    {tag, "v7.3.0"}}},
         {eblake2, "1.0.0"},
         {jsx, {git, "https://github.com/talentdeficit/jsx.git",
                      {tag, "v2.11.0"}}},
@@ -21,7 +21,7 @@
                   {tag, "2.9.0"}}}
        ]}.
 
-{relx, [{release, {aesophia_http, "7.4.0"}, [aesophia_http, sasl, aeserialization]},
+{relx, [{release, {aesophia_http, "7.5.0"}, [aesophia_http, sasl, aeserialization]},
 
         {sys_config, "./config/sys.config"},
         {vm_args, "./config/vm.args"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -9,7 +9,7 @@
   0},
  {<<"aesophia">>,
   {git,"https://github.com/aeternity/aesophia.git",
-       {ref,"43c8328615ae3752c1e80ea74a9dbade8123e655"}},
+       {ref,"67948513d5a582491ef521e353dcab25934c7f33"}},
   0},
  {<<"base58">>,
   {git,"https://github.com/aeternity/erl-base58.git",


### PR DESCRIPTION
Note: this aligns the HTTP API version with the HTTP Compiler version - 7.5.0. 

It also bumps the Sophia compiler to v7.3.0.

This PR is supported by the Æternity Crypto Foundation
