### PR TITLE
Do healthcheck more frequently at startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,5 +37,4 @@ COPY ./docker/entrypoint.sh /docker-entrypoint.sh
 COPY ./docker/healthcheck.sh /healthcheck.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-HEALTHCHECK --timeout=3s CMD /healthcheck.sh
-
+HEALTHCHECK --timeout=3s --retries=6 CMD /healthcheck.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ COPY ./docker/entrypoint.sh /docker-entrypoint.sh
 COPY ./docker/healthcheck.sh /healthcheck.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-HEALTHCHECK --timeout=3s --retries=6 CMD /healthcheck.sh
+HEALTHCHECK --start-period=5s --start-interval=1s --timeout=3s --retries=6 CMD /healthcheck.sh

--- a/docker/healthcheck.sh
+++ b/docker/healthcheck.sh
@@ -4,5 +4,4 @@
 
 EXTERNAL_ADDRESS=${EXTERNAL_ADDRESS:-localhost:3080}
 
-curl -s -f -S -o /dev/null --retry 6 http://${EXTERNAL_ADDRESS}/version || exit 1
-
+curl -s -f -S -o /dev/null http://${EXTERNAL_ADDRESS}/version || exit 1


### PR DESCRIPTION
This PR is supported by the Æternity Foundation

docker-compose.yml
```
version: '3'
services:
  compiler:
    build: ../aesophia_http/
    hostname: compiler
    ports: ["3080:3080"]
```

Before this PR:
```
$ docker compose up compiler -d --wait
[+] Running 1/1
 ✔ Container aepp-sdk-js-compiler-1  Healthy 30.7s
```

With `--start-period=10s --start-interval=2s`:
```
$ docker compose up compiler -d --wait
[+] Running 1/1
 ✔ Container aepp-sdk-js-compiler-1  Healthy 2.7s
```

With `--start-period=5s --start-interval=1s`:
```
$ docker compose up compiler -d --wait
[+] Running 1/1
 ✔ Container aepp-sdk-js-compiler-1  Healthy 1.9s
```
