### PR TITLE
Swagger deprecation notice and added openAPI spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,3 +235,5 @@ curl http://localhost:3080/api
 
 {"basePath":"/","definitions":{  ... },"info":{ ... },"paths":{ ... },"schemes":["http"],"swagger":"2.0"}
 ```
+
+Note that in a future release the swagger specification will be replaced by an OpenAPI 3.0 specification.

--- a/config/oas3.yaml
+++ b/config/oas3.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Aeternity compiler
   description: This is the [Aeternity](https://www.aeternity.com/) compiler API.
-  version: 8.0.0-rc
+  version: 8.0.0
   termsOfService: https://www.aeternity.com/terms/
   contact:
     email: https://github.com/aeternity/aesophia_http/issues

--- a/config/oas3.yaml
+++ b/config/oas3.yaml
@@ -1,0 +1,600 @@
+openapi: 3.0.0
+info:
+  title: Aeternity compiler
+  description: This is the [Aeternity](https://www.aeternity.com/) compiler API.
+  version: 8.0.0-rc
+  termsOfService: https://www.aeternity.com/terms/
+  contact:
+    email: https://github.com/aeternity/aesophia_http/issues
+servers:
+  - url: /
+paths:
+  /aci:
+    post:
+      description: Generate an Aeternity Contract Interface (ACI) for contract
+      operationId: GenerateACI
+      requestBody:
+        description: contract code
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Contract'
+        required: true
+      responses:
+        '200':
+          description: ACI for contract
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ACI'
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorOrCompilerErrors'
+      x-codegen-request-body-name: body
+  /compile:
+    post:
+      description: Compile a sophia contract from source and return byte code
+      operationId: CompileContract
+      requestBody:
+        description: contract code
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Contract'
+        required: true
+      responses:
+        '200':
+          description: Byte code response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ByteCode'
+        '400':
+          description: Invalid data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorOrCompilerErrors'
+      x-codegen-request-body-name: body
+  /decode-call-result:
+    post:
+      description: Decode the result of contract call
+      operationId: DecodeCallResult
+      requestBody:
+        description: Binary data in Sophia ABI format
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SophiaCallResultInput'
+        required: true
+      responses:
+        '200':
+          description: Json encoded data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SophiaCallResult'
+        '400':
+          description: Invalid data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorOrCompilerErrors'
+      x-codegen-request-body-name: body
+  /decode-call-result/bytecode:
+    post:
+      description: Decode the result of contract call from Bytecode
+      operationId: DecodeCallResultBytecode
+      requestBody:
+        description: Call result + compiled contract
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BytecodeCallResultInput'
+        required: true
+      responses:
+        '200':
+          description: Json encoded data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DecodedCallresult'
+        '400':
+          description: Invalid data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorOrCompilerErrors'
+      x-codegen-request-body-name: body
+  /encode-calldata:
+    post:
+      description: Encode Sophia function call according to sophia ABI.
+      operationId: EncodeCalldata
+      requestBody:
+        description: Sophia function call - contract code + function name + arguments
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FunctionCallInput'
+        required: true
+      responses:
+        '200':
+          description: Binary encoded calldata
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Calldata'
+        '400':
+          description: Invalid data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorOrCompilerErrors'
+      x-codegen-request-body-name: body
+  /decode-calldata/bytecode:
+    post:
+      description: Identify function name and arguments in Calldata for a compiled
+        contract
+      operationId: DecodeCalldataBytecode
+      requestBody:
+        description: Calldata + compiled contract
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DecodeCalldataBytecode'
+        required: true
+      responses:
+        '200':
+          description: Binary encoded calldata
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DecodedCalldata'
+        '400':
+          description: Invalid data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-codegen-request-body-name: body
+  /decode-calldata/source:
+    post:
+      description: Identify function name and arguments in Calldata for a (partial)
+        contract
+      operationId: DecodeCalldataSource
+      requestBody:
+        description: Calldata + contract (stub) code
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DecodeCalldataSource'
+        required: true
+      responses:
+        '200':
+          description: Binary encoded calldata
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DecodedCalldata'
+        '400':
+          description: Invalid data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorOrCompilerErrors'
+      x-codegen-request-body-name: body
+  /fate-assembler:
+    post:
+      description: Get FATE assembler code from bytecode
+      operationId: GetFateAssemblerCode
+      requestBody:
+        description: contract byte array
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ByteCodeInput'
+        required: true
+      responses:
+        '200':
+          description: The FATE assembler
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FateAssembler'
+        '400':
+          description: Invalid data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-codegen-request-body-name: body
+  /validate-byte-code:
+    post:
+      description: Verify that an encoded byte array is the result of compiling a
+        given contract
+      operationId: ValidateByteCode
+      requestBody:
+        description: contract byte array and source code
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidateByteCodeInput'
+        required: true
+      responses:
+        '200':
+          description: Validation successful
+          content: {}
+        '400':
+          description: Invalid data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorOrCompilerErrors'
+      x-codegen-request-body-name: body
+  /compiler-version:
+    post:
+      description: Extract compiler version from bytecode
+      operationId: GetCompilerVersion
+      requestBody:
+        description: contract byte array
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ByteCodeInput'
+        required: true
+      responses:
+        '200':
+          description: The compiler version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompilerVersion'
+        '400':
+          description: Invalid data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-codegen-request-body-name: body
+  /version:
+    get:
+      description: Get the version of the underlying Sophia compiler version
+      operationId: Version
+      responses:
+        '200':
+          description: Sophia compiler version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompilerVersion'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /api-version:
+    get:
+      description: Get the version of the API
+      operationId: ApiVersion
+      responses:
+        '200':
+          description: Sophia compiler version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiVersion'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /api:
+    get:
+      description: Get the Api description
+      operationId: Api
+      parameters:
+        - in: query
+          name: oas3
+          description: 'Get OpenApi3 instead of Swagger'
+          schema:
+            default: false
+            type: boolean
+      responses:
+        '200':
+          description: API description
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/API'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Contract:
+      type: object
+      properties:
+        code:
+          type: string
+        options:
+          $ref: '#/components/schemas/CompileOpts'
+      required:
+        - code
+    CompileOpts:
+      type: object
+      properties:
+        file_system:
+          type: object
+          properties: {}
+          description: An explicit file system, mapping file names to file content
+        src_file:
+          type: string
+          description: Name of contract source file - only used in error messages
+    ApiVersion:
+      type: object
+      properties:
+        api-version:
+          type: string
+          description: API compiler version
+      required:
+        - api-version
+    CompilerVersion:
+      type: object
+      properties:
+        version:
+          type: string
+          description: Sophia compiler version
+      required:
+        - version
+    ErrorOrCompilerErrors:
+      oneOf:
+        - $ref: '#/components/schemas/Error'
+        - $ref: '#/components/schemas/CompilerErrors'
+    Error:
+      type: object
+      properties:
+        reason:
+          type: string
+      required:
+        - reason
+    CompilerErrors:
+      type: array
+      items:
+        $ref: '#/components/schemas/CompilerError'
+    CompilerError:
+      type: object
+      properties:
+        type:
+          type: string
+        pos:
+          $ref: '#/components/schemas/ErrorPos'
+        message:
+          type: string
+        context:
+          type: string
+      required:
+        - message
+        - pos
+        - type
+    ErrorPos:
+      type: object
+      properties:
+        file:
+          type: string
+        line:
+          type: integer
+        col:
+          type: integer
+      required:
+        - col
+        - line
+    ACI:
+      type: object
+      properties:
+        encoded_aci:
+          type: object
+          properties: {}
+        external_encoded_aci:
+          type: array
+          items:
+            type: object
+            properties: {}
+        interface:
+          type: string
+      required:
+        - encoded_aci
+        - interface
+    API:
+      type: object
+      description: OpenAPI API description
+    ByteCode:
+      type: object
+      properties:
+        bytecode:
+          $ref: '#/components/schemas/EncodedByteArray'
+      required:
+        - bytecode
+    SophiaCallResultInput:
+      type: object
+      properties:
+        source:
+          type: string
+          description: (Possibly partial) Sophia contract code/interface
+        options:
+          $ref: '#/components/schemas/CompileOpts'
+        function:
+          type: string
+          description: Name of the called function
+        call-result:
+          type: string
+          description: Call result type (ok | revert | error)
+        call-value:
+          type: string
+          description: Call result value (ABI encoded data or error string)
+      required:
+        - call-result
+        - call-value
+        - function
+        - source
+    SophiaCallResult:
+      oneOf:
+        - type: object
+        - type: array
+        - type: string
+        - type: number
+    SophiaBinaryData:
+      type: object
+      properties:
+        sophia-type:
+          type: string
+        data:
+          type: string
+      required:
+        - data
+        - sophia-type
+    SophiaJsonData:
+      type: object
+      properties:
+        data:
+          type: object
+          properties: {}
+      required:
+        - data
+    FunctionCallInput:
+      type: object
+      properties:
+        source:
+          type: string
+          description: (Possibly partial) Sophia contract code
+        options:
+          $ref: '#/components/schemas/CompileOpts'
+        function:
+          type: string
+          description: Name of function to call
+        arguments:
+          type: array
+          description: Array of function call arguments
+          items:
+            type: string
+      required:
+        - arguments
+        - function
+        - source
+    BytecodeCallResultInput:
+      type: object
+      properties:
+        bytecode:
+          $ref: '#/components/schemas/EncodedByteArray'
+        function:
+          type: string
+          description: Name of the called function
+        call-result:
+          type: string
+          description: Call result type (ok | revert | error)
+        call-value:
+          type: string
+          description: Call result value (ABI encoded data or error string)
+      required:
+        - bytecode
+        - call-result
+        - call-value
+        - function
+    DecodeCalldataBytecode:
+      type: object
+      properties:
+        calldata:
+          $ref: '#/components/schemas/EncodedByteArray'
+          description: 'Calldata to dissect'
+        bytecode:
+          $ref: '#/components/schemas/EncodedByteArray'
+          description: 'Compiled contract'
+      required:
+        - bytecode
+        - calldata
+    DecodeCalldataSource:
+      type: object
+      properties:
+        source:
+          type: string
+          description: (Possibly partial) Sophia contract code
+        options:
+          $ref: '#/components/schemas/CompileOpts'
+        calldata:
+          $ref: '#/components/schemas/EncodedByteArray'
+        function:
+          type: string
+          description: Name of the function to call
+      required:
+        - calldata
+        - function
+        - source
+    ByteCodeInput:
+      type: object
+      properties:
+        bytecode:
+          $ref: '#/components/schemas/EncodedByteArray'
+      required:
+        - bytecode
+    ValidateByteCodeInput:
+      type: object
+      properties:
+        bytecode:
+          $ref: '#/components/schemas/EncodedByteArray'
+          description: 'Compiled contract'
+        source:
+          type: string
+          description: Sophia contract source code
+        options:
+          $ref: '#/components/schemas/CompileOpts'
+      required:
+        - bytecode
+        - source
+    DecodedCallresult:
+      type: object
+      properties:
+        function:
+          type: string
+        result:
+          $ref: '#/components/schemas/SophiaCallResult'
+      required:
+        - function
+        - result
+    DecodedCalldata:
+      type: object
+      properties:
+        function:
+          type: string
+        arguments:
+          type: array
+          items:
+            type: object
+            properties: {}
+      required:
+        - arguments
+        - function
+    Calldata:
+      type: object
+      properties:
+        calldata:
+          $ref: '#/components/schemas/EncodedByteArray'
+      required:
+        - calldata
+    EncodedByteArray:
+      type: string
+      description: Prefixed (cb_) Base64Check encoded byte array
+    FateAssembler:
+      type: object
+      properties:
+        fate-assembler:
+          type: string
+          description: Fate assembler code
+      required:
+        - fate-assembler

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -1,11 +1,11 @@
 swagger: '2.0'
 info:
-  description: 'This is the [Aeternity](https://www.aeternity.com/) compiler API.'
+  description: 'This is the [Aeternity](https://www.aeternity.com/) compiler API. The swagger version of this API will be deprecated and replaced by an openAPI 3.x specification'
   version: 8.0.0-rc1
   title: Aeternity compiler
   termsOfService: 'https://www.aeternity.com/terms/'
   contact:
-    email: apiteam@aeternity.com
+    url: 'https://github.com/aeternity/aesophia_http/issues'
 basePath: /
 paths:
   /aci:


### PR DESCRIPTION
In future release we want to use OpenAPI 3.x instead of Swagger.
This PR is a preparation for that.

Plan to use this as starting point to fix PR #113 in a good way. 

This PR is supported by the Æternity Foundation